### PR TITLE
Invalid utf8 data error handling

### DIFF
--- a/Sources/AES256CBC.swift
+++ b/Sources/AES256CBC.swift
@@ -185,7 +185,10 @@ final public class AES256CBC {
         let data = Data(base64Encoded: str)!
         let dec = try Data(bytes: AESCipher(key: keyData.bytes,
                                             iv: ivData.bytes).decrypt(bytes: data.bytes))
-        return String(data: dec, encoding: String.Encoding.utf8)!
+        guard let decryptStr = String(data: dec, encoding: String.Encoding.utf8) else {
+            throw NSError(domain: "Invalid utf8 data", code: 0, userInfo: nil)
+        }
+        return decryptStr
     }
 
 }


### PR DESCRIPTION
It's so useful to throw an error is the utf8 data is invalid instead of crashing.